### PR TITLE
fix: copy python in venv creation

### DIFF
--- a/plugin_utils/installer.py
+++ b/plugin_utils/installer.py
@@ -99,6 +99,7 @@ def ensure_venv(p, exit_on_miss: bool = False):
                 "python",
                 "-m",
                 "venv",
+                "--copies",
                 p
             ]
         )


### PR DESCRIPTION
> Try to use copies rather than symlinks, even when symlinks are the default for the platform.

https://docs.python.org/3/library/venv.html

Fixes bug in creation of venv in Ubuntu

Please review @Momen-Mawad @StefanReder  