### PR TITLE
Fix creation of ZIP-File

### DIFF
--- a/.github/workflows/on-push-tags.yml
+++ b/.github/workflows/on-push-tags.yml
@@ -9,13 +9,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@master
-      - name: Archive Release
-        uses: thedoctor0/zip-release@0.7.5
+      - uses: actions/checkout@v4
         with:
-          type: 'zip'
-          filename: 'WINMOL_Analyser_QGIS_Plugin.zip'
-          exclusions: '*.git* documentation/* documentation/assets/* winmol_venv/* Dockerfile startDocker.sh .github/* standalone/input/* standalone/output/* standalone/model/* standalone/pred/*'
+          path: WINMOL_Analyzer
+      - name: Archive Release
+        uses: montudor/action-zip@v1
+        with:
+          args: zip -r WINMOL_Analyzer_QGIS_Plugin.zip WINMOL_Analyzer -x "*.git*" -x "*documentation/*" -x "*winmol_venv/*" -x "*Dockerfile" -x "*startDocker.sh" -x "*.github/*" -x "*standalone/input/*" -x "*standalone/output/*" -x "*standalone/model/*" -x "*standalone/pred/*" -x "*__pycache*" -x "*pylintrc"
       - name: Upload Release
         uses: ncipollo/release-action@v1.12.0
         with:

--- a/metadata.txt
+++ b/metadata.txt
@@ -7,7 +7,7 @@ name=WINMOL Analyzer
 
 qgisMinimumVersion=3.0
 description=Plugin to detect stems from UAV
-version=0.1
+version=0.2.1
 author=Hochschule für nachhaltige Entwicklung Eberswalde | mundialis GmbH & Co. KG | terrestris GmbH & Co. KG
 email=Stefan.Reder@hnee.de
 


### PR DESCRIPTION
Currently, the plugin sources are not contained in a subfolder. This leads to  an error while installing the plugin to QGIS.
This MR fixes this.

Please review @StefanReder 

P.S.: As soon this is merges I suggest to create a new release (by creating a git tag) in order to provide a new version of the plugin.