### PR TITLE
fix: typo in zip file name

### DIFF
--- a/.github/workflows/on-push-tags.yml
+++ b/.github/workflows/on-push-tags.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Upload Release
         uses: ncipollo/release-action@v1.12.0
         with:
-          artifacts: "WINMOL_Analyser_QGIS_Plugin.zip"
+          artifacts: "WINMOL_Analyzer_QGIS_Plugin.zip"
           allowUpdates: true
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See title.

Herewith, the created ZIP file will be published as release (currently only source code ZIP archives)

